### PR TITLE
Always point to the main branch of PyMAPDL

### DIFF
--- a/requirements/requirements_doc.txt
+++ b/requirements/requirements_doc.txt
@@ -1,5 +1,5 @@
 #PyMAPDL dependencies
-ansys-mapdl-core==0.63.3
+git+https://github.com/pyansys/pymapdl@main
 numpy==1.23.1
 pandas==1.5.1
 plotly==5.11.0


### PR DESCRIPTION
As title says