### PR TITLE
Adding breadcrumb for examples

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -22,6 +22,7 @@ html_theme_options = {
     "additional_breadcrumbs": [
         ("PyAnsys", "https://docs.pyansys.com/"),
         ("PyMAPDL", "https://mapdl.docs.pyansys.com/"),
+        ("Examples", "https://mapdl.docs.pyansys.com/examples/"),
     ],
 }
 


### PR DESCRIPTION
This will also add a breadcrumb for going back to the Examples page for PyMAPDL docs